### PR TITLE
Fix import casing in Header component

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import classes from './Header.module.css';
+import classes from './header.module.css';
 
 const Header = () => {
   const getNavLinkClass = ({ isActive }) => {


### PR DESCRIPTION
## Summary
- fix path case for Header module CSS file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f9120ade0832083aab531d9c08e67